### PR TITLE
List all versions in one line, instead of one per line

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -34,6 +34,6 @@ function sort_versions() {
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval "$cmd" | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"//;s/\",//' | sort_versions)
+versions=$(eval "$cmd" | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"//;s/\",//' | sort_versions | tr '\n' ' ')
 
 echo "$versions"


### PR DESCRIPTION
The list was being printed as 

```0.0.2
0.0.3
0.0.4
0.0.5
[...]
0.9.0
```
Instead of the correct, one line print, this was because of the sort to print it all in order.

Now prints like this by just removing the new lines: 

```0.0.2 0.0.3 0.0.4 0.0.5 0.0.6 [...] 0 0.9.0```
